### PR TITLE
CI: Add missing @ in version for cargo-release

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-semver-checks@0.42.0,cargo-release0.25.18
+          tool: cargo-semver-checks@0.42.0,cargo-release@0.25.18
 
       - name: Set Git Author (required for cargo-release)
         run: |


### PR DESCRIPTION
#### Problem

There's a missing `@` in the cargo-release version, so it's failing to install in CI.

#### Summary of changes

Add. That. `@`.